### PR TITLE
chore(deps-dev): Bump @storybook/vue3, @storybook/vue3-vite and @types/node

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.3.8",
-    "@storybook/vue3": "^10.1.4",
-    "@storybook/vue3-vite": "^10.1.4",
-    "@types/node": "^25.0.2",
+    "@storybook/vue3": "^10.1.10",
+    "@storybook/vue3-vite": "^10.1.10",
+    "@types/node": "^25.0.3",
     "@vitejs/plugin-vue": "^6.0.3",
     "@vue/language-plugin-pug": "^3.1.8",
     "@vue/tsconfig": "^0.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,13 +48,13 @@ importers:
         specifier: ^2.3.8
         version: 2.3.8
       '@storybook/vue3':
-        specifier: ^10.1.4
+        specifier: ^10.1.10
         version: 10.1.10(storybook@10.1.10(@testing-library/dom@10.4.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vue@3.5.25(typescript@5.9.3))
       '@storybook/vue3-vite':
-        specifier: ^10.1.4
+        specifier: ^10.1.10
         version: 10.1.10(esbuild@0.27.2)(rollup@4.53.3)(storybook@10.1.10(@testing-library/dom@10.4.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@7.3.0(@types/node@25.0.3)(sass@1.97.0)(terser@5.44.1))(vue@3.5.25(typescript@5.9.3))
       '@types/node':
-        specifier: ^25.0.2
+        specifier: ^25.0.3
         version: 25.0.3
       '@vitejs/plugin-vue':
         specifier: ^6.0.3


### PR DESCRIPTION
- Bump @storybook/vue3 from 10.1.4 to 10.1.10
- Bump @storybook/vue3-vite from 10.1.4 to 10.1.10
- Bump @types/node from 25.0.2 to 25.0.3
