### PR TITLE
chore(dependabot): align PR title prefixes with Conventional Commits

### DIFF
--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -34,11 +34,11 @@ body:
       required: false
 
   - type: textarea
-    id: improvement
+    id: acceptance
     attributes:
-      label: 改善案
-      description: 期待する改善後の状態やアプローチを記載してください
-      placeholder: "例: 保存処理を非同期化し、進捗インジケータを表示する"
+      label: 完了条件 / メトリクス
+      description: 改善が完了したと判断できる条件や SLA を記載してください
+      placeholder: "例: `/tree` が 1s 未満で応答 / wrangler dev で GC が発生しない"
     validations:
       required: false
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,9 @@ updates:
   labels:
     - "dependencies"
     - "ci"
+  commit-message:
+    prefix: "chore"
+    include: "scope"
 
 # ─────────────────────────────────────────────────────────
 # 2) Node.js (pnpm-lock.yaml) の依存を監視
@@ -38,7 +41,8 @@ updates:
   open-pull-requests-limit: 10
   rebase-strategy: "auto"
   commit-message:
-    prefix: "deps"
+    prefix: "fix"
+    prefix-development: "chore"
     include: "scope"
   groups:
     kiota:


### PR DESCRIPTION
## 📌 概要

<!-- このPRの目的・背景を簡潔に書いてください -->
Dependabot が作成する PR タイトルの prefix を見直し、Conventional Commits の運用に寄せました。

## 🛠 変更内容

<!-- このPRで加えた変更をリストアップしてください -->
- npm 依存更新の PR タイトル prefix を分離
  - dependencies → `fix`
  - devDependencies → `chore`
- GitHub Actions 更新の PR タイトル prefix を `chore(ci)` に統一
- `include: scope` を有効化し、更新対象（package / group）がタイトルから判別できるように変更

## ✅ 確認事項

- [x] Dependabot が作成する PR タイトルの先頭が以下になること
- [x] 既存の groups / ignore 設定に影響がないこと

## 留意点

<!-- このPRを使用するうえで注意すべきことをリストアップしてください。 -->
<!-- 必要がなければ N/A としてください -->
Closes #59 